### PR TITLE
adds ReplicationSpec to Cluster struct

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -27,9 +27,9 @@ type AutoScaling struct {
 // ReplicationSpec describes a region’s priority in elections,
 // and the number and type of MongoDB nodes Atlas deploys to the region.
 type ReplicationSpec struct {
-	Priority       int `json:"priority,omitempty"`
-	ElectableNodes int `json:"electableNodes,omitempty"`
-	ReadOnlyNodes  int `json:"readOnlyNodes,omitempty"`
+	Priority       int `json:"priority"`
+	ElectableNodes int `json:"electableNodes"`
+	ReadOnlyNodes  int `json:"readOnlyNodes"`
 }
 
 // ProviderSettings is the configuration for the provisioned servers on which MongoDB runs.

--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -24,6 +24,14 @@ type AutoScaling struct {
 	DiskGBEnabled bool `json:"diskGBEnabled"`
 }
 
+// ReplicationSpec describes a region’s priority in elections,
+// and the number and type of MongoDB nodes Atlas deploys to the region.
+type ReplicationSpec struct {
+	Priority       int `json:"priority,omitempty"`
+	ElectableNodes int `json:"electableNodes,omitempty"`
+	ReadOnlyNodes  int `json:"readOnlyNodes,omitempty"`
+}
+
 // ProviderSettings is the configuration for the provisioned servers on which MongoDB runs.
 // The available options are specific to the cloud service provider.
 type ProviderSettings struct {
@@ -35,22 +43,23 @@ type ProviderSettings struct {
 
 // Cluster represents a Cluster configuration in MongoDB.
 type Cluster struct {
-	ID                  string           `json:"id,omitempty"`
-	GroupID             string           `json:"groupId,omitempty"`
-	Name                string           `json:"name,omitempty"`
-	MongoDBVersion      string           `json:"mongoDBVersion,omitempty"`
-	MongoDBMajorVersion string           `json:"mongoDBMajorVersion,omitempty"`
-	MongoURI            string           `json:"mongoURI,omitempty"`
-	MongoURIUpdated     string           `json:"mongoURIUpdated,omitempty"`
-	MongoURIWithOptions string           `json:"mongoURIWithOptions,omitempty"`
-	DiskSizeGB          float64          `json:"diskSizeGB,omitempty"`
-	BackupEnabled       bool             `json:"backupEnabled"`
-	StateName           string           `json:"stateName,omitempty"`
-	ReplicationFactor   int              `json:"replicationFactor,omitempty"`
-	NumShards           int              `json:"numShards,omitempty"`
-	Paused              bool             `json:"paused"`
-	AutoScaling         AutoScaling      `json:"autoScaling,omitempty"`
-	ProviderSettings    ProviderSettings `json:"providerSettings,omitempty"`
+	ID                  string                     `json:"id,omitempty"`
+	GroupID             string                     `json:"groupId,omitempty"`
+	Name                string                     `json:"name,omitempty"`
+	MongoDBVersion      string                     `json:"mongoDBVersion,omitempty"`
+	MongoDBMajorVersion string                     `json:"mongoDBMajorVersion,omitempty"`
+	MongoURI            string                     `json:"mongoURI,omitempty"`
+	MongoURIUpdated     string                     `json:"mongoURIUpdated,omitempty"`
+	MongoURIWithOptions string                     `json:"mongoURIWithOptions,omitempty"`
+	DiskSizeGB          float64                    `json:"diskSizeGB,omitempty"`
+	BackupEnabled       bool                       `json:"backupEnabled"`
+	StateName           string                     `json:"stateName,omitempty"`
+	ReplicationFactor   int                        `json:"replicationFactor,omitempty"`
+	ReplicationSpec     map[string]ReplicationSpec `json:"replicationSpec,omitempty"`
+	NumShards           int                        `json:"numShards,omitempty"`
+	Paused              bool                       `json:"paused"`
+	AutoScaling         AutoScaling                `json:"autoScaling,omitempty"`
+	ProviderSettings    ProviderSettings           `json:"providerSettings,omitempty"`
 }
 
 // clusterListResponse is the response from the ClusterService.List.

--- a/mongodbatlas/clusters_test.go
+++ b/mongodbatlas/clusters_test.go
@@ -62,6 +62,13 @@ func TestClusterService_Create(t *testing.T) {
 				"regionName":       "US_EAST_1",
 				"instanceSizeName": "M0",
 			},
+			"replicationSpec": map[string]interface{}{
+				"US_EAST_1": map[string]interface{}{
+					"priority":       float64(7),
+					"electableNodes": float64(2),
+					"readOnlyNodes":  float64(1),
+				},
+			},
 		}
 		assertReqJSON(t, expectedBody, r)
 		fmt.Fprintf(w, `{
@@ -78,12 +85,22 @@ func TestClusterService_Create(t *testing.T) {
 				"providerName":"AWS",
 				"regionName":"US_EAST_1",
 				"instanceSizeName":"M0"
+			},
+			"replicationSpec":{
+				"US_EAST_1":{
+					"priority":7,
+					"electableNodes":2,
+					"readOnlyNodes":1
+				}
 			}
 		}`)
 	})
 
 	client := NewClient(httpClient)
 	providerSettings := ProviderSettings{ProviderName: "AWS", RegionName: "US_EAST_1", InstanceSizeName: "M0"}
+	replicationSpec := map[string]ReplicationSpec{
+		"US_EAST_1": ReplicationSpec{Priority: 7, ElectableNodes: 2, ReadOnlyNodes: 1},
+	}
 	params := &Cluster{
 		Name:                "test",
 		MongoDBMajorVersion: "3.4",
@@ -91,6 +108,7 @@ func TestClusterService_Create(t *testing.T) {
 		BackupEnabled:       false,
 		DiskSizeGB:          10.5,
 		ProviderSettings:    providerSettings,
+		ReplicationSpec:     replicationSpec,
 	}
 	cluster, _, err := client.Clusters.Create("123", params)
 	expected := &Cluster{
@@ -101,6 +119,7 @@ func TestClusterService_Create(t *testing.T) {
 		Paused:              false,
 		DiskSizeGB:          10,
 		ProviderSettings:    providerSettings,
+		ReplicationSpec:     replicationSpec,
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, cluster)
@@ -137,6 +156,13 @@ func TestClusterService_Update(t *testing.T) {
 				"providerName":"AWS",
 				"regionName":"US_EAST_1",
 				"instanceSizeName":"M0"
+			},
+			"replicationSpec":{
+				"US_EAST_1":{
+					"priority":7,
+					"electableNodes":2,
+					"readOnlyNodes":1
+				}
 			}
 		}`)
 	})
@@ -147,6 +173,9 @@ func TestClusterService_Update(t *testing.T) {
 	}
 	cluster, _, err := client.Clusters.Update("123", "test", params)
 	providerSettings := ProviderSettings{ProviderName: "AWS", RegionName: "US_EAST_1", InstanceSizeName: "M0"}
+	replicationSpec := map[string]ReplicationSpec{
+		"US_EAST_1": ReplicationSpec{Priority: 7, ElectableNodes: 2, ReadOnlyNodes: 1},
+	}
 	expected := &Cluster{
 		Name:                "test",
 		MongoDBMajorVersion: "3.4",
@@ -155,6 +184,7 @@ func TestClusterService_Update(t *testing.T) {
 		Paused:              false,
 		DiskSizeGB:          float64(5),
 		ProviderSettings:    providerSettings,
+		ReplicationSpec:     replicationSpec,
 	}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, cluster)


### PR DESCRIPTION
The `replicationSpec` parameter is used for multi-region clusters.

Documentation here: https://docs.atlas.mongodb.com/reference/api/clusters-create-one/#request-body-parameters