### PR TITLE
Added organizations support to API

### DIFF
--- a/mongodbatlas/mongodb.go
+++ b/mongodbatlas/mongodb.go
@@ -18,6 +18,7 @@ type Client struct {
 	Containers    *ContainerService
 	Peers         *PeerService
 	DatabaseUsers *DatabaseUserService
+	Organizations *OrganizationService
 }
 
 // NewClient returns a new Client.
@@ -32,5 +33,6 @@ func NewClient(httpClient *http.Client) *Client {
 		Containers:    newContainerService(base.New()),
 		Peers:         newPeerService(base.New()),
 		DatabaseUsers: newDatabaseUserService(base.New()),
+		Organizations: newOrganizationService(base.New()),
 	}
 }

--- a/mongodbatlas/organizations.go
+++ b/mongodbatlas/organizations.go
@@ -1,0 +1,79 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// OrganizationService provides methods for accessing MongoDB Atlas Organizations API endpoints.
+type OrganizationService struct {
+	sling *sling.Sling
+}
+
+// newOrganizationService returns a new OrganizationService.
+func newOrganizationService(sling *sling.Sling) *OrganizationService {
+	return &OrganizationService{
+		sling: sling.Path("orgs/"),
+	}
+}
+
+// Organization represents an organization's connection information in MongoDB.
+type Organization struct {
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
+}
+
+// organizationListResponse is the response from the OrganizationService.List.
+type organizationListResponse struct {
+	Results    []Organization `json:"results"`
+	TotalCount int            `json:"totalCount"`
+}
+
+// List all organizations the authenticated user has access to.
+// https://docs.atlas.mongodb.com/reference/api/organization-get-all/
+func (c *OrganizationService) List() ([]Organization, *http.Response, error) {
+	response := new(organizationListResponse)
+	apiError := new(APIError)
+	resp, err := c.sling.New().Get("").Receive(response, apiError)
+	return response.Results, resp, relevantError(err, *apiError)
+}
+
+// Get information about the organization associated to org ID
+// https://docs.atlas.mongodb.com/reference/api/organization-get-one/
+func (c *OrganizationService) Get(id string) (*Organization, *http.Response, error) {
+	organization := new(Organization)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Get(path).Receive(organization, apiError)
+	return organization, resp, relevantError(err, *apiError)
+}
+
+// Create an organization.
+// https://docs.atlas.mongodb.com/reference/api/organization-create-one/
+func (c *OrganizationService) Create(organizationParams *Organization) (*Organization, *http.Response, error) {
+	organization := new(Organization)
+	apiError := new(APIError)
+	resp, err := c.sling.New().Post("").BodyJSON(organizationParams).Receive(organization, apiError)
+	return organization, resp, relevantError(err, *apiError)
+}
+
+// Update name of an organization.
+// https://docs.atlas.mongodb.com/reference/api/organization-rename/
+func (c *OrganizationService) Update(id string, organizationParams *Organization) (*Organization, *http.Response, error) {
+	organization := new(Organization)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Patch(path).BodyJSON(organizationParams).Receive(organization, apiError)
+	return organization, resp, relevantError(err, *apiError)
+}
+
+// Delete an organization
+// https://docs.atlas.mongodb.com/reference/api/organization-delete-one/
+func (c *OrganizationService) Delete(id string) (*http.Response, error) {
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Delete(path).Receive(nil, apiError)
+	return resp, relevantError(err, *apiError)
+}

--- a/mongodbatlas/organizations_test.go
+++ b/mongodbatlas/organizations_test.go
@@ -1,0 +1,119 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrganizationService_List(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/orgs/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"links":[],"results": [{"id":"5b20401dc0c6e334a832b26d","links":[],"name":"OrganizationFoo"}],"totalCount":1}`)
+	})
+
+	client := NewClient(httpClient)
+	organizations, _, err := client.Organizations.List()
+	fmt.Println(err)
+	expected := []Organization{
+		Organization{
+			ID:   "5b20401dc0c6e334a832b26d",
+			Name: "OrganizationFoo",
+		},
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, organizations)
+}
+
+func TestOrganizationService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/orgs/5b20401dc0c6e334a832b26d", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"id":"5b20401dc0c6e334a832b26d", "links":[], "name":"OrganizationFoo"}`)
+	})
+
+	client := NewClient(httpClient)
+	organization, _, err := client.Organizations.Get("5b20401dc0c6e334a832b26d")
+	expected := &Organization{
+		ID:   "5b20401dc0c6e334a832b26d",
+		Name: "OrganizationFoo",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, organization)
+}
+
+func TestOrganizationService_Create(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/orgs/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"name": "OrganizationFoo",
+		}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{"id":"5b20401dc0c6e334a832b26d","name":"OrganizationFoo"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &Organization{
+		Name: "OrganizationFoo",
+	}
+	organization, _, err := client.Organizations.Create(params)
+	expected := &Organization{
+		ID:   "5b20401dc0c6e334a832b26d",
+		Name: "OrganizationFoo",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, organization)
+}
+
+func TestOrganizationService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/orgs/5b20401dc0c6e334a832b26d", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PATCH", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"name": "OrganizationFoo",
+		}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{"id":"5b20401dc0c6e334a832b26d","links":[],"name":"OrganizationFoo"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &Organization{
+		Name: "OrganizationFoo",
+	}
+	organization, _, err := client.Organizations.Update("5b20401dc0c6e334a832b26d", params)
+	expected := &Organization{
+		ID:   "5b20401dc0c6e334a832b26d",
+		Name: "OrganizationFoo",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, organization)
+}
+
+func TestOrganizationService_Delete(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/orgs/5b20401dc0c6e334a832b26d", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+		fmt.Fprintf(w, `{}`)
+	})
+
+	client := NewClient(httpClient)
+	resp, err := client.Organizations.Delete("5b20401dc0c6e334a832b26d")
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}


### PR DESCRIPTION
Implements create, read, list, update, and delete operations for organizations.

Relates to https://github.com/akshaykarle/terraform-provider-mongodbatlas/issues/5