### PR TITLE
Add alert configurations

### DIFF
--- a/mongodbatlas/alert_configurations.go
+++ b/mongodbatlas/alert_configurations.go
@@ -1,0 +1,154 @@
+package mongodbatlas
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// AlertConfigurationService provides methods for accessing MongoDB Atlas Alert Configurations API endpoints.
+type AlertConfigurationService struct {
+	sling *sling.Sling
+}
+
+// newAlertConfigurationService returns a new AlertConfigurationService.
+func newAlertConfigurationService(sling *sling.Sling) *AlertConfigurationService {
+	return &AlertConfigurationService{
+		sling: sling.Path("groups/"),
+	}
+}
+
+// Notification is a way to get notified when a metric crosses the threshold
+type Notification struct {
+	TypeName            string `json:"typeName,omitempty"`
+	IntervalMin         int    `json:"intervalMin,omitempty"`
+	DelayMin            int    `json:"delayMin,omitempty"`
+	EmailEnabled        bool   `json:"emailEnabled,omitempty"`
+	SMSEnabled          bool   `json:"smsEnabled,omitempty"`
+	Username            string `json:"username,omitempty"`
+	TeamID              string `json:"teamId,omitempty"`
+	EmailAddress        string `json:"emailAddress,omitempty"`
+	MobileNumber        string `json:"mobileNumber,omitempty"`
+	NotificationToken   string `json:"notificationToken,omitempty"`
+	RoomName            string `json:"roomName,omitempty"`
+	ChannelName         string `json:"channelName,omitempty"`
+	APIToken            string `json:"apiToken,omitempty"`
+	OrgName             string `json:"orgName,omitempty"`
+	FlowName            string `json:"flowName,omitempty"`
+	FlowdockAPIToken    string `json:"flowdockApiToken,omitempty"`
+	ServiceKey          string `json:"serviceKey,omitempty"`
+	VictorOpsAPIKey     string `json:"victorOpsApiKey,omitempty"`
+	VictorOpsRoutingKey string `json:"victorOpsRoutingKey,omitempty"`
+	OpsGenieAPIKey      string `json:"opsGenieApiKey,omitempty"`
+}
+
+// MetricThreshold describes how to know when to trigger this alert
+type MetricThreshold struct {
+	MetricName string  `json:"metricName,omitempty"`
+	Operator   string  `json:"operator,omitempty"`
+	Threshold  float64 `json:"threshold,omitempty"`
+	Units      string  `json:"units,omitempty"`
+	Mode       string  `json:"mode,omitempty"`
+}
+
+// Matcher contains the metric(s) we'd like to alert on
+type Matcher struct {
+	FieldName string `json:"fieldName,omitempty"`
+	Operator  string `json:"operator,omitempty"`
+	Value     string `json:"value,omitempty"`
+}
+
+// AlertConfiguration represents an AlertConfiguration in MongoDB.
+type AlertConfiguration struct {
+	ID              string          `json:"id,omitempty"`
+	GroupID         string          `json:"groupId,omitempty"`
+	EventTypeName   string          `json:"eventTypeName,omitempty"`
+	Enabled         bool            `json:"enabled,omitempty"`
+	Notifications   []Notification  `json:"notifications,omitempty"`
+	MetricThreshold MetricThreshold `json:"metricThreshold,omitempty"`
+	Matchers        []Matcher       `json:"matchers,omitempty"`
+}
+
+// MarshalJSON is custom defined here because the API pukes if you specify an empty metricThreshold ("metricThreshold":{}) when it doesn't want one
+func (r AlertConfiguration) MarshalJSON() ([]byte, error) {
+	encoded := struct {
+		ID              string           `json:"id,omitempty"`
+		GroupID         string           `json:"groupId,omitempty"`
+		EventTypeName   string           `json:"eventTypeName,omitempty"`
+		Enabled         bool             `json:"enabled,omitempty"`
+		Notifications   []Notification   `json:"notifications,omitempty"`
+		MetricThreshold *MetricThreshold `json:"metricThreshold,omitempty"`
+		Matchers        []Matcher        `json:"matchers,omitempty"`
+	}{
+		ID:            r.ID,
+		GroupID:       r.GroupID,
+		EventTypeName: r.EventTypeName,
+		Enabled:       r.Enabled,
+		Notifications: r.Notifications,
+		Matchers:      r.Matchers,
+	}
+	// only add the metric threshold if it's not empty
+	if (MetricThreshold{}) != r.MetricThreshold {
+		encoded.MetricThreshold = &r.MetricThreshold
+	}
+
+	return json.Marshal(encoded)
+}
+
+// alertConfigsListResponse is the response from the AlertConfigurationService.List.
+type alertConfigsListResponse struct {
+	Results    []AlertConfiguration `json:"results"`
+	TotalCount int                  `json:"totalCount"`
+}
+
+// List all alert configurations for the specified group.
+// https://docs.atlas.mongodb.com/reference/api/alert-configurations-get-all-configs/
+func (c *AlertConfigurationService) List(gid string) ([]AlertConfiguration, *http.Response, error) {
+	response := new(alertConfigsListResponse)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/alertConfigs", gid)
+	resp, err := c.sling.New().Get(path).Receive(response, apiError)
+	return response.Results, resp, relevantError(err, *apiError)
+}
+
+// Get an alert configuration in the specified group.
+// https://docs.atlas.mongodb.com/reference/api/alert-configurations-get-config/
+func (c *AlertConfigurationService) Get(gid string, id string) (*AlertConfiguration, *http.Response, error) {
+	alert := new(AlertConfiguration)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/alertConfigs/%s", gid, id)
+	resp, err := c.sling.New().Get(path).Receive(alert, apiError)
+	return alert, resp, relevantError(err, *apiError)
+}
+
+// Create an alert configuration in the specified group.
+// https://docs.atlas.mongodb.com/reference/api/alert-configurations-create-config/
+func (c *AlertConfigurationService) Create(gid string, alertConfigurationParams *AlertConfiguration) (*AlertConfiguration, *http.Response, error) {
+	alert := new(AlertConfiguration)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/alertConfigs", gid)
+	resp, err := c.sling.New().Post(path).BodyJSON(alertConfigurationParams).Receive(alert, apiError)
+	return alert, resp, relevantError(err, *apiError)
+}
+
+// Update an alert configuration in the specified group.
+// https://docs.atlas.mongodb.com/reference/api/alert-configurations-update-config/
+func (c *AlertConfigurationService) Update(gid string, id string, alertConfigurationParams *AlertConfiguration) (*AlertConfiguration, *http.Response, error) {
+	alert := new(AlertConfiguration)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/alertConfigs/%s", gid, id)
+	resp, err := c.sling.New().Put(path).BodyJSON(alertConfigurationParams).Receive(alert, apiError)
+	return alert, resp, relevantError(err, *apiError)
+}
+
+// Delete an alert configuration in the specified group.
+// https://docs.atlas.mongodb.com/reference/api/alert-configurations-update-config/
+func (c *AlertConfigurationService) Delete(gid string, id string) (*http.Response, error) {
+	alert := new(AlertConfiguration)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/alertConfigs/%s", gid, id)
+	resp, err := c.sling.New().Delete(path).Receive(alert, apiError)
+	return resp, relevantError(err, *apiError)
+}

--- a/mongodbatlas/alert_configurations_test.go
+++ b/mongodbatlas/alert_configurations_test.go
@@ -1,0 +1,112 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAlertConfigurationService_List(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/alertConfigs", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"links":[],"results":[{"id":"533dc40ae4b00835ff81eaee","groupId":"535683b3794d371327b"}],"totalCount":1}`)
+	})
+
+	client := NewClient(httpClient)
+	alertConfigurations, _, err := client.AlertConfigurations.List("123")
+	expected := []AlertConfiguration{AlertConfiguration{ID: "533dc40ae4b00835ff81eaee", GroupID: "535683b3794d371327b"}}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, alertConfigurations)
+}
+
+func TestAlertConfigurationService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/alertConfigs/533dc40ae4b00835ff81eaee", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"id":"533dc40ae4b00835ff81eaee","groupId":"535683b3794d371327b"}`)
+	})
+
+	client := NewClient(httpClient)
+	alert, _, err := client.AlertConfigurations.Get("123", "533dc40ae4b00835ff81eaee")
+	expected := &AlertConfiguration{ID: "533dc40ae4b00835ff81eaee", GroupID: "535683b3794d371327b"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, alert)
+}
+
+func TestAlertConfigurationService_Create(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/alertConfigs", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"metricThreshold": map[string]interface{}{
+				"threshold": 12.0,
+			},
+			"eventTypeName": "HOST_RESTARTED",
+			"enabled":       true,
+		}
+
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{"id":"533dc40ae4b00835ff81eaee","groupId":"535683b3794d371327b"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &AlertConfiguration{EventTypeName: "HOST_RESTARTED", Enabled: true}
+	params.MetricThreshold.Threshold = 12
+	alert, _, err := client.AlertConfigurations.Create("123", params)
+	expected := &AlertConfiguration{ID: "533dc40ae4b00835ff81eaee", GroupID: "535683b3794d371327b"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, alert)
+}
+
+func TestAlertConfiguration_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/alertConfigs/533dc40ae4b00835ff81eaee", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PUT", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"metricThreshold": map[string]interface{}{
+				"threshold": 74.0,
+			},
+			"eventTypeName": "HOST_RESTARTED",
+			"enabled":       true,
+		}
+
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{"id":"533dc40ae4b00835ff81eaee","groupId":"535683b3794d371327b"}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &AlertConfiguration{EventTypeName: "HOST_RESTARTED", Enabled: true}
+	params.MetricThreshold.Threshold = 74
+	alert, _, err := client.AlertConfigurations.Update("123", "533dc40ae4b00835ff81eaee", params)
+	expected := &AlertConfiguration{ID: "533dc40ae4b00835ff81eaee", GroupID: "535683b3794d371327b"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, alert)
+}
+
+func TestAlertConfiguration_Delete(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/alertConfigs/alertConfigs", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+		fmt.Fprintf(w, `{}`)
+	})
+
+	client := NewClient(httpClient)
+	resp, err := client.AlertConfigurations.Delete("123", "alertConfigs")
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
+}

--- a/mongodbatlas/mongodb.go
+++ b/mongodbatlas/mongodb.go
@@ -10,29 +10,32 @@ const apiURL = "https://cloud.mongodb.com/api/atlas/v1.0/"
 
 // Client is a MongoDB Atlas client for making MongoDB API requests.
 type Client struct {
-	sling         *sling.Sling
-	Root          *RootService
-	Whitelist     *WhitelistService
-	Projects      *ProjectService
-	Clusters      *ClusterService
-	Containers    *ContainerService
-	Peers         *PeerService
-	DatabaseUsers *DatabaseUserService
-	Organizations *OrganizationService
+	sling               *sling.Sling
+	Root                *RootService
+	Whitelist           *WhitelistService
+	Projects            *ProjectService
+	Clusters            *ClusterService
+	Containers          *ContainerService
+	Peers               *PeerService
+	DatabaseUsers       *DatabaseUserService
+	Organizations       *OrganizationService
+	AlertConfigurations *AlertConfigurationService
 }
 
 // NewClient returns a new Client.
 func NewClient(httpClient *http.Client) *Client {
 	base := sling.New().Client(httpClient).Base(apiURL)
+
 	return &Client{
-		sling:         base,
-		Root:          newRootService(base.New()),
-		Whitelist:     newWhitelistService(base.New()),
-		Projects:      newProjectService(base.New()),
-		Clusters:      newClusterService(base.New()),
-		Containers:    newContainerService(base.New()),
-		Peers:         newPeerService(base.New()),
-		DatabaseUsers: newDatabaseUserService(base.New()),
-		Organizations: newOrganizationService(base.New()),
+		sling:               base,
+		Root:                newRootService(base.New()),
+		Whitelist:           newWhitelistService(base.New()),
+		Projects:            newProjectService(base.New()),
+		Clusters:            newClusterService(base.New()),
+		Containers:          newContainerService(base.New()),
+		Peers:               newPeerService(base.New()),
+		DatabaseUsers:       newDatabaseUserService(base.New()),
+		Organizations:       newOrganizationService(base.New()),
+		AlertConfigurations: newAlertConfigurationService(base.New()),
 	}
 }


### PR DESCRIPTION
## Purpose
Provide support for alert configurations (https://github.com/akshaykarle/terraform-provider-mongodbatlas/issues/7)


## Notable changes
* Add CRUD support for alert configurations.
* There is some badness in the API where it will reject requests that specify `"metricThreshold":{}` when it doesn't want it. I had to override `MarshalJSON` and conditionally set that property. Please let me know if there's a better way to do this.
* Add support for outputting API requests/responses to a file to make it easier to debug the API interactions. I hope this isn't already achievable via some obvious environment variable - I'm new to Go and I couldn't find a way.