### PR TITLE
Add DiskIOPS and EncryptEBS options for create cluster provider settings

### DIFF
--- a/mongodbatlas/clusters.go
+++ b/mongodbatlas/clusters.go
@@ -39,6 +39,8 @@ type ProviderSettings struct {
 	BackingProviderName string `json:"backingProviderName,omitempty"`
 	RegionName          string `json:"regionName,omitempty"`
 	InstanceSizeName    string `json:"instanceSizeName,omitempty"`
+	DiskIOPS            int    `json:"diskIOPS,omitempty"`
+	EncryptEBSVolume    bool   `json:"encryptEBSVolume,omitempty"`
 }
 
 // Cluster represents a Cluster configuration in MongoDB.


### PR DESCRIPTION
I am using this lib to help write a DB automation tool and found that we needed a couple of options that were not natively exposed. I added them in my fork and figured upstream could benefit.