### PR TITLE
Introduce the Teams API from MongoDB Atlas

### DIFF
--- a/mongodbatlas/teams.go
+++ b/mongodbatlas/teams.go
@@ -1,79 +1,79 @@
 package mongodbatlas
 
 import (
-  "fmt"
-  "net/http"
+	"fmt"
+	"net/http"
 
-  "github.com/dghubble/sling"
+	"github.com/dghubble/sling"
 )
 
 // TeamService provides methods for accessing Atlas Teams API endpoints.
 type TeamService struct {
-  sling *sling.Sling
+	sling *sling.Sling
 }
 
 // newTeamService returns a new TeamService.
 func newTeamService(sling *sling.Sling) *TeamService {
-  return *TeamService{
-    sling: sling.Path("orgs/"),
-  }
+	return &TeamService{
+		sling: sling.Path("orgs/"),
+	}
 }
 
 // Team represents a team's connection information in MongoDB.
 type Team struct {
-  ID   string `json:"id,omitempty"`
-  Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+	Name string `json:"name,omitempty"`
 }
 
 // teamListResponse is the response from the TeamService.List.
 type teamListResponse struct {
-  Results    []Team `json:"results"`
-  TotalCount int    `json:"totalCount"`
+	Results    []Team `json:"results"`
+	TotalCount int    `json:"totalCount"`
 }
 
 // List all teams the authenticated user belongs to.
 // https://docs.atlas.mongodb.com/reference/api/teams-get-all/
 func (c *TeamService) List() ([]Team, *http.Response, error) {
-  response := new(teamListResponse)
-  apiError := new(APIError)
-  resp, err := c.sling.New().Get("").Receive(response, apiError)
-  return response.Results, resp, relevantError(err, *apiError)
+	response := new(teamListResponse)
+	apiError := new(APIError)
+	resp, err := c.sling.New().Get("").Receive(response, apiError)
+	return response.Results, resp, relevantError(err, *apiError)
 }
 
 // Get information about the team associated to team ID
 // https://docs.atlas.mongodb.com/reference/api/teams-get-one-by-name/
 func (c *TeamService) Get(id string, name string) (*Team, *http.Response, error) {
-  team := new(Team)
-  apiError := new(APIError)
-  path := fmt.Sprintf("%s/teams/byName/%s", id, name)
-  resp, err := c.sling.New().Get(path).Receive(alert, apiError)
-  return alert, resp, relevantError(err, *apiError)
+	team := new(Team)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/teams/byName/%s", id, name)
+	resp, err := c.sling.New().Get(path).Receive(team, apiError)
+	return team, resp, relevantError(err, *apiError)
 }
 
 // Create a team.
 // https://docs.atlas.mongodb.com/reference/api/teams-create-one/
 func (c *TeamService) Create(teamParams *Team) (*Team, *http.Response, error) {
-  team := new(Team)
-  apiError := new(APIError)
-  resp, err := c.sling.New().Post("").BodyJSON(teamParams).Receive(team, apiError)
-  return team, resp, relevantError(err, *apiError)
+	team := new(Team)
+	apiError := new(APIError)
+	resp, err := c.sling.New().Post("").BodyJSON(teamParams).Receive(team, apiError)
+	return team, resp, relevantError(err, *apiError)
 }
 
 // Update name of a team.
 // https://docs.atlas.mongodb.com/reference/api/teams-rename-one/
-func(c *TeamService) Update(id string, teamParams *Team) (*Team, *http.Response, error) {
-  team := new(Team)
-  apiError := new(APIError)
-  path := fmt.Sprintf("%s", id)
-  resp, err := c.sling.New().Patch(path).BodyJSON(teamParams).Receive(team, apiError)
-  return team, resp, relevantError(err, *apiError)
+func (c *TeamService) Update(id string, teamParams *Team) (*Team, *http.Response, error) {
+	team := new(Team)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Patch(path).BodyJSON(teamParams).Receive(team, apiError)
+	return team, resp, relevantError(err, *apiError)
 }
 
 // Delete a team
 // https://docs.atlas.mongodb.com/reference/api/teams-delete-one/
 func (c *TeamService) Delete(id string) (*http.Response, error) {
-  apiError := new(APIError)
-  path := fmt.Sprintf("%s", id)
-  resp, err := c.sling.New().Delete(path).Receive(nil, apiError)
-  return resp, relevantError(err, *apiError)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Delete(path).Receive(nil, apiError)
+	return resp, relevantError(err, *apiError)
 }

--- a/mongodbatlas/teams.go
+++ b/mongodbatlas/teams.go
@@ -1,0 +1,79 @@
+package mongodbatlas
+
+import (
+  "fmt"
+  "net/http"
+
+  "github.com/dghubble/sling"
+)
+
+// TeamService provides methods for accessing Atlas Teams API endpoints.
+type TeamService struct {
+  sling *sling.Sling
+}
+
+// newTeamService returns a new TeamService.
+func newTeamService(sling *sling.Sling) *TeamService {
+  return *TeamService{
+    sling: sling.Path("orgs/"),
+  }
+}
+
+// Team represents a team's connection information in MongoDB.
+type Team struct {
+  ID   string `json:"id,omitempty"`
+  Name string `json:"name,omitempty"`
+}
+
+// teamListResponse is the response from the TeamService.List.
+type teamListResponse struct {
+  Results    []Team `json:"results"`
+  TotalCount int    `json:"totalCount"`
+}
+
+// List all teams the authenticated user belongs to.
+// https://docs.atlas.mongodb.com/reference/api/teams-get-all/
+func (c *TeamService) List() ([]Team, *http.Response, error) {
+  response := new(teamListResponse)
+  apiError := new(APIError)
+  resp, err := c.sling.New().Get("").Receive(response, apiError)
+  return response.Results, resp, relevantError(err, *apiError)
+}
+
+// Get information about the team associated to team ID
+// https://docs.atlas.mongodb.com/reference/api/teams-get-one-by-name/
+func (c *TeamService) Get(id string, name string) (*Team, *http.Response, error) {
+  team := new(Team)
+  apiError := new(APIError)
+  path := fmt.Sprintf("%s/teams/byName/%s", id, name)
+  resp, err := c.sling.New().Get(path).Receive(alert, apiError)
+  return alert, resp, relevantError(err, *apiError)
+}
+
+// Create a team.
+// https://docs.atlas.mongodb.com/reference/api/teams-create-one/
+func (c *TeamService) Create(teamParams *Team) (*Team, *http.Response, error) {
+  team := new(Team)
+  apiError := new(APIError)
+  resp, err := c.sling.New().Post("").BodyJSON(teamParams).Receive(team, apiError)
+  return team, resp, relevantError(err, *apiError)
+}
+
+// Update name of a team.
+// https://docs.atlas.mongodb.com/reference/api/teams-rename-one/
+func(c *TeamService) Update(id string, teamParams *Team) (*Team, *http.Response, error) {
+  team := new(Team)
+  apiError := new(APIError)
+  path := fmt.Sprintf("%s", id)
+  resp, err := c.sling.New().Patch(path).BodyJSON(teamParams).Receive(team, apiError)
+  return team, resp, relevantError(err, *apiError)
+}
+
+// Delete a team
+// https://docs.atlas.mongodb.com/reference/api/teams-delete-one/
+func (c *TeamService) Delete(id string) (*http.Response, error) {
+  apiError := new(APIError)
+  path := fmt.Sprintf("%s", id)
+  resp, err := c.sling.New().Delete(path).Receive(nil, apiError)
+  return resp, relevantError(err, *apiError)
+}

--- a/mongodbatlas/teams_test.go
+++ b/mongodbatlas/teams_test.go
@@ -1,0 +1,96 @@
+package mongodbatlas
+
+import (
+  "fmt"
+  "net/http"
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+)
+
+func TestTeamService_List(t *testing.T) {
+  httpClient, mux, server := testServer()
+  defer server.Close()
+
+  mux.Handlefunc("/api/atlas/v1.0/orgs/123/teams/", func(w http.ResponseWritter, r *http.Request) {
+    assertMethod(t, "GET", r)
+    fmt.Fprintf(w, `{"links":[],"results": [{"id":"b5cfec387d9d63926b9189g","name":"test"}],"totalCount":1}`)
+  })
+
+  client := NewClient(httpClient)
+  teams, _, err := client.Teams.List("123")
+  expected := []Team{Team{Name: "test"}}
+  assert.Nil(t, err)
+  assert.Equal(t, expected, teams)
+}
+
+func TestTeamService_Get(t *testing.T) {
+  httpClient, mux, server := testServer()
+  defer server.Close()
+
+  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
+    asserMethod(t, "GET", r)
+    fmt.Fprintf(w, `{"name":"test"}`)
+  })
+
+  client := NewClient(httpClient)
+  team, _, err := team.Teams.Get("123", "test")
+  expected := &Team{Name: "test"}
+  assert.Nil(t, err)
+  assert.Equal(t, expected, team)
+}
+
+func TestTeamServer_Create(t *testing.T) {
+  httpClient, mux, server := testServer()
+  defer server.Close()
+
+  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams", func(w http.ResponseWriter, r *http.Request) {
+    assertMethod(t, "POST", r)
+    w.Header().Set("Content-Type", "application/json")
+    expectedBody := map[string]interface{}{"name": "test"}
+    assertReqJSON(t, expectedBody, r)
+    fmt.Fprintf(w, `{"name":"test"}`)
+  })
+
+  client := NewClient(httpClient)
+  params := &Team{Name: "test"}
+  team, _, err := team.Teams.Create("123", params)
+  expected := &Team{Name: "test"}
+  assert.Nil(t, err)
+  assert.Equal(t, expected, cluster)
+}
+
+func TestTeamService_Update(t *testing.T) {
+  httpClient, mux, server := testServer()
+  defer server.Close()
+
+  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
+    assertMethod(t, "PATCH", r)
+    w.Header().Set("Content-Type", "application/json")
+    expectedBody := map[string]interface{}{"name": "test"}
+    assertReqJSON(t, expectedBody, r)
+    fmt.Fprintf(w, `{"name":"test"}`)
+  })
+
+  client := NewClient(httpClient)
+  params := &Team{Name: "test2"}
+  team, _, err := client.Teams.Update("123", "test", params)
+  expected := &Team{Name: "test2"}
+  assert.Nil(t, err)
+  assert.Equal(t, expected, cluster)
+}
+
+func TestTeamService_Delete(t *testing.T) {
+  httpClient, mux, server := testServer()
+  defer server.Close()
+
+  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
+    assertMethod(t, "DELETE", r)
+    fmt.Fprintf(w, `{}`)
+  })
+
+  client := NewClient(httpClient)
+  resp, err := client.Teams.Delete("123", "test")
+  assert.Nil(t, err)
+  assert.Equal(t, 200, resp.StatusCode)
+}

--- a/mongodbatlas/teams_test.go
+++ b/mongodbatlas/teams_test.go
@@ -1,96 +1,96 @@
 package mongodbatlas
 
 import (
-  "fmt"
-  "net/http"
-  "testing"
+	"fmt"
+	"net/http"
+	"testing"
 
-  "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTeamService_List(t *testing.T) {
-  httpClient, mux, server := testServer()
-  defer server.Close()
+	httpClient, mux, server := testServer()
+	defer server.Close()
 
-  mux.Handlefunc("/api/atlas/v1.0/orgs/123/teams/", func(w http.ResponseWritter, r *http.Request) {
-    assertMethod(t, "GET", r)
-    fmt.Fprintf(w, `{"links":[],"results": [{"id":"b5cfec387d9d63926b9189g","name":"test"}],"totalCount":1}`)
-  })
+	mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"links":[],"results": [{"id":"i123","name":"test"}],"totalCount":1}`)
+	})
 
-  client := NewClient(httpClient)
-  teams, _, err := client.Teams.List("123")
-  expected := []Team{Team{Name: "test"}}
-  assert.Nil(t, err)
-  assert.Equal(t, expected, teams)
+	client := NewClient(httpClient)
+	teams, _, err := client.Team.List("123")
+	expected := []Team{Team{Name: "test"}}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, teams)
 }
 
 func TestTeamService_Get(t *testing.T) {
-  httpClient, mux, server := testServer()
-  defer server.Close()
+	httpClient, mux, server := testServer()
+	defer server.Close()
 
-  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
-    asserMethod(t, "GET", r)
-    fmt.Fprintf(w, `{"name":"test"}`)
-  })
+	mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
+		asserMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"name":"test"}`)
+	})
 
-  client := NewClient(httpClient)
-  team, _, err := team.Teams.Get("123", "test")
-  expected := &Team{Name: "test"}
-  assert.Nil(t, err)
-  assert.Equal(t, expected, team)
+	client := NewClient(httpClient)
+	team, _, err := team.Teams.Get("123", "test")
+	expected := &Team{Name: "test"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, team)
 }
 
 func TestTeamServer_Create(t *testing.T) {
-  httpClient, mux, server := testServer()
-  defer server.Close()
+	httpClient, mux, server := testServer()
+	defer server.Close()
 
-  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams", func(w http.ResponseWriter, r *http.Request) {
-    assertMethod(t, "POST", r)
-    w.Header().Set("Content-Type", "application/json")
-    expectedBody := map[string]interface{}{"name": "test"}
-    assertReqJSON(t, expectedBody, r)
-    fmt.Fprintf(w, `{"name":"test"}`)
-  })
+	mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{"name": "test"}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{"name":"test"}`)
+	})
 
-  client := NewClient(httpClient)
-  params := &Team{Name: "test"}
-  team, _, err := team.Teams.Create("123", params)
-  expected := &Team{Name: "test"}
-  assert.Nil(t, err)
-  assert.Equal(t, expected, cluster)
+	client := NewClient(httpClient)
+	params := &Team{Name: "test"}
+	team, _, err := team.Teams.Create("123", params)
+	expected := &Team{Name: "test"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, cluster)
 }
 
 func TestTeamService_Update(t *testing.T) {
-  httpClient, mux, server := testServer()
-  defer server.Close()
+	httpClient, mux, server := testServer()
+	defer server.Close()
 
-  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
-    assertMethod(t, "PATCH", r)
-    w.Header().Set("Content-Type", "application/json")
-    expectedBody := map[string]interface{}{"name": "test"}
-    assertReqJSON(t, expectedBody, r)
-    fmt.Fprintf(w, `{"name":"test"}`)
-  })
+	mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PATCH", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{"name": "test"}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{"name":"test"}`)
+	})
 
-  client := NewClient(httpClient)
-  params := &Team{Name: "test2"}
-  team, _, err := client.Teams.Update("123", "test", params)
-  expected := &Team{Name: "test2"}
-  assert.Nil(t, err)
-  assert.Equal(t, expected, cluster)
+	client := NewClient(httpClient)
+	params := &Team{Name: "test2"}
+	team, _, err := client.Teams.Update("123", "test", params)
+	expected := &Team{Name: "test2"}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, cluster)
 }
 
 func TestTeamService_Delete(t *testing.T) {
-  httpClient, mux, server := testServer()
-  defer server.Close()
+	httpClient, mux, server := testServer()
+	defer server.Close()
 
-  mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
-    assertMethod(t, "DELETE", r)
-    fmt.Fprintf(w, `{}`)
-  })
+	mux.HandleFunc("/api/atlas/v1.0/orgs/123/teams/test", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "DELETE", r)
+		fmt.Fprintf(w, `{}`)
+	})
 
-  client := NewClient(httpClient)
-  resp, err := client.Teams.Delete("123", "test")
-  assert.Nil(t, err)
-  assert.Equal(t, 200, resp.StatusCode)
+	client := NewClient(httpClient)
+	resp, err := client.Teams.Delete("123", "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 200, resp.StatusCode)
 }


### PR DESCRIPTION
Implements create, read, list, update, and delete operations for teams.

Relates to https://github.com/akshaykarle/terraform-provider-mongodbatlas/issues/45