### PR TITLE
Introduce the Snapshot Schedule API from MongoDB Atlas

### DIFF
--- a/examples/clusters.go
+++ b/examples/clusters.go
@@ -23,37 +23,59 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Clusters list: %v\n", clusters)
+	fmt.Printf("Clusters list: \n%v\n\n", clusters)
 
 	// Clusters.Get example
 	cluster, _, err := client.Clusters.Get(gid, clusters[0].Name)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Clusters get: %v\n", cluster)
+	fmt.Printf("Clusters get: \n%v\n\n", cluster)
 
 	// Clusters.Create example
 	providerSettings := ma.ProviderSettings{ProviderName: "AWS", RegionName: "US_EAST_1", InstanceSizeName: "M10"}
-	params := &ma.Cluster{Name: "test", ReplicationFactor: 3, DiskSizeGB: 0.5, BackupEnabled: false, ProviderSettings: providerSettings}
+	params := &ma.Cluster{Name: "test", ReplicationFactor: 3, DiskSizeGB: 1, BackupEnabled: false, ProviderSettings: providerSettings}
 	cluster, _, err = client.Clusters.Create(gid, params)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Cluster created: %v\n", cluster)
+	fmt.Printf("Cluster created: \n%v\n\n", cluster)
 
 	// Clusters.Update example
 	providerSettings = ma.ProviderSettings{ProviderName: "AWS", RegionName: "US_EAST_1", InstanceSizeName: "M10"}
-	params = &ma.Cluster{Name: "test", ReplicationFactor: 3, DiskSizeGB: 5, BackupEnabled: false, ProviderSettings: providerSettings}
+	params = &ma.Cluster{Name: "test", ReplicationFactor: 3, DiskSizeGB: 5, BackupEnabled: true, ProviderSettings: providerSettings}
 	cluster, _, err = client.Clusters.Update(gid, "test", params)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Cluster updated: %v\n", cluster)
+	fmt.Printf("Cluster updated: \n%v\n\n", cluster)
+
+	// SnapshotSchedule.Get example
+	snapshotSchedule, _, err := client.SnapshotSchedule.Get(gid, "test")
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Snapshot Schedule Get: \n%v\n\n", snapshotSchedule)
+
+	// SnapshotSchedule.Update example
+	snapshotScheduleParams := &ma.SnapshotSchedule{
+		SnapshotIntervalHours:          10,
+		SnapshotRetentionDays:          4,
+		DailySnapshotRetentionDays:     7,
+		PointInTimeWindowHours:         24,
+		WeeklySnapshotRetentionWeeks:   4,
+		MonthlySnapshotRetentionMonths: 13,
+	}
+	snapshotSchedule, _, err = client.SnapshotSchedule.Update(gid, "test", snapshotScheduleParams)
+	if err != nil {
+		log.Fatal(err)
+	}
+	fmt.Printf("Snapshot Schedule updated: \n%v\n\n", snapshotSchedule)
 
 	// Clusters.Delete example
 	_, err = client.Clusters.Delete(gid, "test")
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("Cluster deleted: %v\n", cluster)
+	fmt.Printf("Cluster deleted: \n%v\n\n", cluster)
 }

--- a/examples/projects.go
+++ b/examples/projects.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	username := os.Args[1]
 	password := os.Args[2]
-	orgId := os.Args[3]
+	orgID := os.Args[3]
 	t := dac.NewTransport(username, password)
 	httpClient := &http.Client{Transport: &t}
 	client := ma.NewClient(httpClient)
@@ -34,7 +34,7 @@ func main() {
 
 	// Projects.Create example
 	params := &ma.Project{
-		OrgID: orgId,
+		OrgID: orgID,
 		Name:  "test",
 	}
 	project, _, err = client.Projects.Create(params)

--- a/examples/projects.go
+++ b/examples/projects.go
@@ -13,7 +13,7 @@ import (
 func main() {
 	username := os.Args[1]
 	password := os.Args[2]
-	// orgId := os.Args[3]
+	orgId := os.Args[3]
 	t := dac.NewTransport(username, password)
 	httpClient := &http.Client{Transport: &t}
 	client := ma.NewClient(httpClient)
@@ -23,14 +23,14 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("projects list: %v\n", projects)
+	fmt.Printf("projects list: \n%v\n\n", projects)
 
 	// Projects.Get example
 	project, _, err := client.Projects.Get(projects[0].ID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("project get: %v\n", project)
+	fmt.Printf("project get: \n%v\n\n", project)
 
 	// Projects.Create example
 	params := &ma.Project{
@@ -41,19 +41,19 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("project created: %v\n", project)
+	fmt.Printf("project created: \n%v\n\n", project)
 
 	// Projects.GetByName example
 	project, _, err = client.Projects.GetByName("test")
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("project get: %v\n", project)
+	fmt.Printf("project get: \n%v\n\n", project)
 
 	// Projects.Delete example
-	_, err = client.Projects.Delete(project.Id)
+	_, err = client.Projects.Delete(project.ID)
 	if err != nil {
 		log.Fatal(err)
 	}
-	fmt.Printf("project deleted: %v\n", project)
+	fmt.Printf("project deleted: \n%v\n\n", project)
 }

--- a/mongodbatlas/mongodb.go
+++ b/mongodbatlas/mongodb.go
@@ -20,6 +20,7 @@ type Client struct {
 	DatabaseUsers       *DatabaseUserService
 	Organizations       *OrganizationService
 	AlertConfigurations *AlertConfigurationService
+	SnapshotSchedule    *SnapshotScheduleService
 }
 
 // NewClient returns a new Client.
@@ -37,5 +38,6 @@ func NewClient(httpClient *http.Client) *Client {
 		DatabaseUsers:       newDatabaseUserService(base.New()),
 		Organizations:       newOrganizationService(base.New()),
 		AlertConfigurations: newAlertConfigurationService(base.New()),
+		SnapshotSchedule:    newSnapshotScheduleService(base.New()),
 	}
 }

--- a/mongodbatlas/snapshot_schedule.go
+++ b/mongodbatlas/snapshot_schedule.go
@@ -1,0 +1,52 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// SnapshotScheduleService provides methods for accessing MongoDB Atlas Snapshot Schedule API endpoints.
+type SnapshotScheduleService struct {
+	sling *sling.Sling
+}
+
+// newSnapshotScheduleService returns a new SnapshotScheduleService.
+func newSnapshotScheduleService(sling *sling.Sling) *SnapshotScheduleService {
+	return &SnapshotScheduleService{
+		sling: sling.Path("groups/"),
+	}
+}
+
+// SnapshotSchedule represents a snapshot schedule's connection information in MongoDB.
+type SnapshotSchedule struct {
+	GroupID                        string  `json:"groupId,omitempty"`
+	ClusterID                      string  `json:"clusterId,omitempty"`
+	SnapshotIntervalHours          float64 `json:"snapshotIntervalHours,omitempty"`
+	SnapshotRetentionDays          float64 `json:"snapshotRetentionDays,omitempty"`
+	DailySnapshotRetentionDays     float64 `json:"dailySnapshotRetentionDays,omitempty"`
+	PointInTimeWindowHours         float64 `json:"pointInTimeWindowHours,omitempty"`
+	WeeklySnapshotRetentionWeeks   float64 `json:"weeklySnapshotRetentionWeeks,omitempty"`
+	MonthlySnapshotRetentionMonths float64 `json:"monthlySnapshotRetentionMonths,omitempty"`
+}
+
+// Get the snapshot schedule for the specified cluster
+// https://docs.atlas.mongodb.com/reference/api/snapshot-schedule-get/
+func (c *SnapshotScheduleService) Get(gid string, clusterName string) (*SnapshotSchedule, *http.Response, error) {
+	snapshotSchedule := new(SnapshotSchedule)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/clusters/%s/snapshotSchedule", gid, clusterName)
+	resp, err := c.sling.New().Get(path).Receive(snapshotSchedule, apiError)
+	return snapshotSchedule, resp, relevantError(err, *apiError)
+}
+
+// Update the snapshot schedule for the specified cluster.
+// https://docs.atlas.mongodb.com/reference/api/snapshot-schedule/
+func (c *SnapshotScheduleService) Update(gid string, clusterName string, snapshotScheduleParams *SnapshotSchedule) (*SnapshotSchedule, *http.Response, error) {
+	snapshotSchedule := new(SnapshotSchedule)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s/clusters/%s/snapshotSchedule", gid, clusterName)
+	resp, err := c.sling.New().Patch(path).BodyJSON(snapshotScheduleParams).Receive(snapshotSchedule, apiError)
+	return snapshotSchedule, resp, relevantError(err, *apiError)
+}

--- a/mongodbatlas/snapshot_schedule.go
+++ b/mongodbatlas/snapshot_schedule.go
@@ -29,6 +29,7 @@ type SnapshotSchedule struct {
 	PointInTimeWindowHours         float64 `json:"pointInTimeWindowHours,omitempty"`
 	WeeklySnapshotRetentionWeeks   float64 `json:"weeklySnapshotRetentionWeeks,omitempty"`
 	MonthlySnapshotRetentionMonths float64 `json:"monthlySnapshotRetentionMonths,omitempty"`
+	ClusterCheckpintIntervalMin    float64 `json:"clusterCheckpintIntervalMin,omitempty"`
 }
 
 // Get the snapshot schedule for the specified cluster

--- a/mongodbatlas/snapshot_schedule_test.go
+++ b/mongodbatlas/snapshot_schedule_test.go
@@ -1,0 +1,101 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotScheduleService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/clusters/Cluster0/snapshotSchedule", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{
+			"groupId":"123",
+			"clusterId":"456",
+			"snapshotIntervalHours":6,
+			"snapshotRetentionDays":2,
+			"dailySnapshotRetentionDays":7,
+			"pointInTimeWindowHours":24,
+			"weeklySnapshotRetentionWeeks": 4,
+			"monthlySnapshotRetentionMonths": 13,
+			"links": []
+		}`)
+	})
+
+	client := NewClient(httpClient)
+	snapshotSchedule, _, err := client.SnapshotSchedule.Get("123", "Cluster0")
+	expected := &SnapshotSchedule{
+		GroupID:                        "123",
+		ClusterID:                      "456",
+		SnapshotIntervalHours:          float64(6),
+		SnapshotRetentionDays:          float64(2),
+		DailySnapshotRetentionDays:     float64(7),
+		PointInTimeWindowHours:         float64(24),
+		WeeklySnapshotRetentionWeeks:   float64(4),
+		MonthlySnapshotRetentionMonths: float64(13),
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, snapshotSchedule)
+}
+
+func TestSnapshotScheduleService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/groups/123/clusters/Cluster0/snapshotSchedule", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PATCH", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"groupId":                        "123",
+			"clusterId":                      "456",
+			"snapshotIntervalHours":          float64(6),
+			"snapshotRetentionDays":          float64(2),
+			"dailySnapshotRetentionDays":     float64(7),
+			"pointInTimeWindowHours":         float64(24),
+			"weeklySnapshotRetentionWeeks":   float64(4),
+			"monthlySnapshotRetentionMonths": float64(13),
+		}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{
+			"groupId":"123",
+			"clusterId":"456",
+			"snapshotIntervalHours":6,
+			"snapshotRetentionDays":2,
+			"dailySnapshotRetentionDays":7,
+			"pointInTimeWindowHours":24,
+			"weeklySnapshotRetentionWeeks": 4,
+			"monthlySnapshotRetentionMonths": 13,
+			"links": []
+		}`)
+	})
+
+	client := NewClient(httpClient)
+	params := &SnapshotSchedule{
+		GroupID:                        "123",
+		ClusterID:                      "456",
+		SnapshotIntervalHours:          float64(6),
+		SnapshotRetentionDays:          float64(2),
+		DailySnapshotRetentionDays:     float64(7),
+		PointInTimeWindowHours:         float64(24),
+		WeeklySnapshotRetentionWeeks:   float64(4),
+		MonthlySnapshotRetentionMonths: float64(13),
+	}
+	snapshotSchedule, _, err := client.SnapshotSchedule.Update("123", "Cluster0", params)
+	expected := &SnapshotSchedule{
+		GroupID:                        "123",
+		ClusterID:                      "456",
+		SnapshotIntervalHours:          float64(6),
+		SnapshotRetentionDays:          float64(2),
+		DailySnapshotRetentionDays:     float64(7),
+		PointInTimeWindowHours:         float64(24),
+		WeeklySnapshotRetentionWeeks:   float64(4),
+		MonthlySnapshotRetentionMonths: float64(13),
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, snapshotSchedule)
+}

--- a/mongodbatlas/snapshot_schedule_test.go
+++ b/mongodbatlas/snapshot_schedule_test.go
@@ -51,8 +51,6 @@ func TestSnapshotScheduleService_Update(t *testing.T) {
 		assertMethod(t, "PATCH", r)
 		w.Header().Set("Content-Type", "application/json")
 		expectedBody := map[string]interface{}{
-			"groupId":                        "123",
-			"clusterId":                      "456",
 			"snapshotIntervalHours":          float64(6),
 			"snapshotRetentionDays":          float64(2),
 			"dailySnapshotRetentionDays":     float64(7),
@@ -76,8 +74,6 @@ func TestSnapshotScheduleService_Update(t *testing.T) {
 
 	client := NewClient(httpClient)
 	params := &SnapshotSchedule{
-		GroupID:                        "123",
-		ClusterID:                      "456",
 		SnapshotIntervalHours:          float64(6),
 		SnapshotRetentionDays:          float64(2),
 		DailySnapshotRetentionDays:     float64(7),


### PR DESCRIPTION
Implements get and patch from the snapshot schedule api: https://docs.atlas.mongodb.com/reference/api/snapshot-schedule/ . 

Relates to [akshaykarle/terraform-provider-mongodbatlas#63](https://github.com/akshaykarle/terraform-provider-mongodbatlas/issues/63)

I don't know yet how to handle the responseElement and request body parameter `clusterCheckpointIntervalMin` (defined [here for example](https://docs.atlas.mongodb.com/reference/api/snapshot-schedule-get/#response-elements)) which is a field only related to sharded clusters. Shall we have separate Get and Update methods for a non-sharded and a sharded cluster or just make it an optional field?