### PR TITLE
Introduce the Atlas Users API from MongoDB Atlas

### DIFF
--- a/mongodbatlas/atlas_users.go
+++ b/mongodbatlas/atlas_users.go
@@ -1,0 +1,81 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/dghubble/sling"
+)
+
+// AtlasUserService provides methods for accessing MongoDB Atlas AtlasUsers API endpoints.
+// https://docs.atlas.mongodb.com/reference/api/user/
+type AtlasUserService struct {
+	sling *sling.Sling
+}
+
+// newAtlasUserService returns a new AtlasUserService.
+func newAtlasUserService(sling *sling.Sling) *AtlasUserService {
+	return &AtlasUserService{
+		sling: sling.Path("users/"),
+	}
+}
+
+// AtlasRole represents the permission on either the organization or group level
+type AtlasRole struct {
+	OrgID    string `json:"orgId,omitempty"`
+	GroupID  string `json:"groupId,omitempty"`
+	RoleName string `json:"roleName,omitempty"`
+}
+
+// AtlasUser represents users in your MongoDB Atlas UI.
+type AtlasUser struct {
+	EmailAddress string      `json:"emailAddress,omitempty"`
+	ID           string      `json:"id,omitempty"`
+	Username     string      `json:"username,omitempty"`
+	FirstName    string      `json:"firstName,omitempty"`
+	LastName     string      `json:"lastName,omitempty"`
+	Password     string      `json:"password,omitempty"`
+	MobileNumber string      `json:"mobileNumber,omitempty"`
+	Country      string      `json:"country,omitempty"`
+	Roles        []AtlasRole `json:"roles,omitempty"`
+	TeamIDs      []string    `json:"teamIds,omitempty"`
+}
+
+// Get an atlasUser by ID.
+// https://docs.atlas.mongodb.com/reference/api/user-get-by-id/
+func (c *AtlasUserService) Get(id string) (*AtlasUser, *http.Response, error) {
+	atlasUser := new(AtlasUser)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Get(path).Receive(atlasUser, apiError)
+	return atlasUser, resp, relevantError(err, *apiError)
+}
+
+// GetByName gets an atlasUser by Name.
+// https://docs.atlas.mongodb.com/reference/api/user-get-one-by-name/
+func (c *AtlasUserService) GetByName(name string) (*AtlasUser, *http.Response, error) {
+	atlasUser := new(AtlasUser)
+	apiError := new(APIError)
+	path := fmt.Sprintf("byName/%s", name)
+	resp, err := c.sling.New().Get(path).Receive(atlasUser, apiError)
+	return atlasUser, resp, relevantError(err, *apiError)
+}
+
+// Create an atlasUser
+// https://docs.atlas.mongodb.com/reference/api/user-create/
+func (c *AtlasUserService) Create(atlasUserParams *AtlasUser) (*AtlasUser, *http.Response, error) {
+	atlasUser := new(AtlasUser)
+	apiError := new(APIError)
+	resp, err := c.sling.New().Post("").BodyJSON(atlasUserParams).Receive(atlasUser, apiError)
+	return atlasUser, resp, relevantError(err, *apiError)
+}
+
+// Update an atlasUser
+// https://docs.atlas.mongodb.com/reference/api/user-update/
+func (c *AtlasUserService) Update(id string, atlasUserParams *AtlasUser) (*AtlasUser, *http.Response, error) {
+	atlasUser := new(AtlasUser)
+	apiError := new(APIError)
+	path := fmt.Sprintf("%s", id)
+	resp, err := c.sling.New().Patch(path).BodyJSON(atlasUserParams).Receive(atlasUser, apiError)
+	return atlasUser, resp, relevantError(err, *apiError)
+}

--- a/mongodbatlas/atlas_users_test.go
+++ b/mongodbatlas/atlas_users_test.go
@@ -1,0 +1,239 @@
+package mongodbatlas
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAtlasUserService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/users/789", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"id": "789",
+			"lastName": "Doe",
+			"links": [],
+			"mobileNumber" : "2125550198",
+			"roles": [
+				{
+					"orgId": "111",
+					"roleName": "ORG_OWNER"
+				},
+				{
+					"groupId": "222",
+					"roleName": "GROUP_OWNER"
+				}
+			],
+			"teamIds": [
+				"333"
+			],
+			"username": "john.doe@example.com"
+		}`)
+	})
+
+	client := NewClient(httpClient)
+	atlasUser, _, err := client.AtlasUsers.Get("789")
+	expectedRoles := []AtlasRole{{OrgID: "111", RoleName: "ORG_OWNER"}, {GroupID: "222", RoleName: "GROUP_OWNER"}}
+	expected := &AtlasUser{
+		EmailAddress: "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		ID:           "789",
+		MobileNumber: "2125550198",
+		Roles:        expectedRoles,
+		TeamIDs:      []string{"333"},
+		Username:     "john.doe@example.com",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, atlasUser)
+}
+
+func TestAtlasUserService_GetByName(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/users/byName/john.doe@example.com", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"id": "789",
+			"lastName": "Doe",
+			"links": [],
+			"mobileNumber": "2125550198",
+			"roles": [
+				{
+					"orgId": "111",
+					"roleName": "ORG_OWNER"
+				},
+				{
+					"groupId": "222",
+					"roleName": "GROUP_OWNER"
+				}
+			],
+			"teamIds": [
+				"333"
+			],
+			"username": "john.doe@example.com"
+		}`)
+	})
+
+	client := NewClient(httpClient)
+	atlasUser, _, err := client.AtlasUsers.GetByName("john.doe@example.com")
+	expectedRoles := []AtlasRole{{OrgID: "111", RoleName: "ORG_OWNER"}, {GroupID: "222", RoleName: "GROUP_OWNER"}}
+	expected := &AtlasUser{
+		EmailAddress: "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		ID:           "789",
+		MobileNumber: "2125550198",
+		Roles:        expectedRoles,
+		TeamIDs:      []string{"333"},
+		Username:     "john.doe@example.com",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, atlasUser)
+}
+
+func TestAtlasUserService_Create(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/users/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "POST", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"username":     "john.doe@example.com",
+			"emailAddress": "john.doe@example.com",
+			"firstName":    "John",
+			"lastName":     "Doe",
+			"password":     "myPassword1@",
+			"mobileNumber": "2125550198",
+			"roles": []interface{}{map[string]interface{}{
+				"orgId":    "111",
+				"roleName": "ORG_OWNER",
+			}, map[string]interface{}{
+				"groupId":  "222",
+				"roleName": "GROUP_OWNER",
+			}},
+			"country": "US",
+		}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{
+			"username": "john.doe@example.com",
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"lastName": "Doe",
+			"id": "789",
+			"mobileNumber" : "2125550198",
+			"links": [],
+			"roles": [
+				{
+					"orgId": "111",
+					"roleName": "ORG_OWNER"
+				},
+				{
+					"groupId": "222",
+					"roleName": "GROUP_OWNER"
+				}
+			],
+			"teamIds": []
+		}`)
+	})
+
+	client := NewClient(httpClient)
+	roles := []AtlasRole{{OrgID: "111", RoleName: "ORG_OWNER"}, {GroupID: "222", RoleName: "GROUP_OWNER"}}
+	params := &AtlasUser{
+		EmailAddress: "john.doe@example.com",
+		Username:     "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		Password:     "myPassword1@",
+		MobileNumber: "2125550198",
+		Country:      "US",
+		Roles:        roles,
+	}
+	atlasUser, _, err := client.AtlasUsers.Create(params)
+	expected := &AtlasUser{
+		EmailAddress: "john.doe@example.com",
+		ID:           "789",
+		Username:     "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		MobileNumber: "2125550198",
+		Roles:        roles,
+		TeamIDs:      []string{},
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, atlasUser)
+}
+
+func TestAtlasUserService_Update(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/atlas/v1.0/users/123", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "PATCH", r)
+		w.Header().Set("Content-Type", "application/json")
+		expectedBody := map[string]interface{}{
+			"country":      "US",
+			"mobileNumber": "2125550198",
+			"roles": []interface{}{map[string]interface{}{
+				"orgId":    "111",
+				"roleName": "ORG_OWNER",
+			}, map[string]interface{}{
+				"groupId":  "222",
+				"roleName": "GROUP_OWNER",
+			}},
+		}
+		assertReqJSON(t, expectedBody, r)
+		fmt.Fprintf(w, `{
+			"username": "john.doe@example.com",
+			"emailAddress": "john.doe@example.com",
+			"firstName": "John",
+			"lastName": "Doe",
+			"id": "123",
+			"mobileNumber" : "2125550198",
+			"links": [],
+			"roles": [
+				{
+					"orgId": "111",
+					"roleName": "ORG_OWNER"
+				},
+				{
+					"groupId": "222",
+					"roleName": "GROUP_OWNER"
+				}
+			],
+			"teamIds": []
+		}`)
+	})
+
+	client := NewClient(httpClient)
+	roles := []AtlasRole{{OrgID: "111", RoleName: "ORG_OWNER"}, {GroupID: "222", RoleName: "GROUP_OWNER"}}
+	params := &AtlasUser{
+		Country:      "US",
+		MobileNumber: "2125550198",
+		Roles:        roles,
+	}
+	atlasUser, _, err := client.AtlasUsers.Update("123", params)
+	expected := &AtlasUser{
+		EmailAddress: "john.doe@example.com",
+		ID:           "123",
+		Username:     "john.doe@example.com",
+		FirstName:    "John",
+		LastName:     "Doe",
+		MobileNumber: "2125550198",
+		Roles:        roles,
+		TeamIDs:      []string{},
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, atlasUser)
+}

--- a/mongodbatlas/mongodb.go
+++ b/mongodbatlas/mongodb.go
@@ -20,6 +20,7 @@ type Client struct {
 	DatabaseUsers       *DatabaseUserService
 	Organizations       *OrganizationService
 	AlertConfigurations *AlertConfigurationService
+	AtlasUsers          *AtlasUserService
 }
 
 // NewClient returns a new Client.
@@ -37,5 +38,6 @@ func NewClient(httpClient *http.Client) *Client {
 		DatabaseUsers:       newDatabaseUserService(base.New()),
 		Organizations:       newOrganizationService(base.New()),
 		AlertConfigurations: newAlertConfigurationService(base.New()),
+		AtlasUsers:          newAtlasUserService(base.New()),
 	}
 }


### PR DESCRIPTION
Implements the Atlas Users API: https://docs.atlas.mongodb.com/reference/api/user/ 

Relates to [akshaykarle/terraform-provider-mongodbatlas#45](https://github.com/akshaykarle/terraform-provider-mongodbatlas/issues/45).