### PR TITLE
Adding deleteAfterDate param for user

### DIFF
--- a/mongodbatlas/database_users.go
+++ b/mongodbatlas/database_users.go
@@ -29,11 +29,12 @@ type Role struct {
 
 // DatabaseUser represents MongoDB users in your cluster.
 type DatabaseUser struct {
-	GroupID      string `json:"groupId,omitempty"`
-	Username     string `json:"username,omitempty"`
-	Password     string `json:"password,omitempty"`
-	DatabaseName string `json:"databaseName,omitempty"`
-	Roles        []Role `json:"roles,omitempty"`
+	GroupID         string `json:"groupId,omitempty"`
+	Username        string `json:"username,omitempty"`
+	Password        string `json:"password,omitempty"`
+	DatabaseName    string `json:"databaseName,omitempty"`
+	DeleteAfterDate string `json:"deleteAfterDate,omitempty"`
+	Roles           []Role `json:"roles,omitempty"`
 }
 
 // databaseUserListResponse is the response from the DatabaseUserService.List.

--- a/mongodbatlas/database_users_test.go
+++ b/mongodbatlas/database_users_test.go
@@ -14,13 +14,13 @@ func TestDatabaseUserService_List(t *testing.T) {
 
 	mux.HandleFunc("/api/atlas/v1.0/groups/123/databaseUsers", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
-		fmt.Fprintf(w, `{"links":[],"results":[{"databaseName":"test","username":"test","roles":[{"databaseName":"test","roleName":"read"}]}],"totalCount":1}`)
+		fmt.Fprintf(w, `{"links":[],"results":[{"databaseName":"test","deleteAfterDate":"2100-01-01T00:00:00Z","username":"test","roles":[{"databaseName":"test","roleName":"read"}]}],"totalCount":1}`)
 	})
 
 	client := NewClient(httpClient)
 	databaseUsers, _, err := client.DatabaseUsers.List("123")
 	expectedRoles := []Role{Role{DatabaseName: "test", RoleName: "read"}}
-	expected := []DatabaseUser{DatabaseUser{DatabaseName: "test", Username: "test", Roles: expectedRoles}}
+	expected := []DatabaseUser{DatabaseUser{DatabaseName: "test", DeleteAfterDate: "2100-01-01T00:00:00Z", Username: "test", Roles: expectedRoles}}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, databaseUsers)
 }
@@ -31,13 +31,13 @@ func TestDatabaseUserService_Get(t *testing.T) {
 
 	mux.HandleFunc("/api/atlas/v1.0/groups/123/databaseUsers/admin/test", func(w http.ResponseWriter, r *http.Request) {
 		assertMethod(t, "GET", r)
-		fmt.Fprintf(w, `{"databaseName":"test","username":"test","roles":[{"databaseName":"test","roleName":"read"}]}`)
+		fmt.Fprintf(w, `{"databaseName":"test","deleteAfterDate":"2100-01-01T00:00:00Z","username":"test","roles":[{"databaseName":"test","roleName":"read"}]}`)
 	})
 
 	client := NewClient(httpClient)
 	databaseUser, _, err := client.DatabaseUsers.Get("123", "test")
 	expectedRoles := []Role{Role{DatabaseName: "test", RoleName: "read"}}
-	expected := &DatabaseUser{DatabaseName: "test", Username: "test", Roles: expectedRoles}
+	expected := &DatabaseUser{DatabaseName: "test", DeleteAfterDate: "2100-01-01T00:00:00Z", Username: "test", Roles: expectedRoles}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, databaseUser)
 }
@@ -50,23 +50,24 @@ func TestDatabaseUserService_Create(t *testing.T) {
 		assertMethod(t, "POST", r)
 		w.Header().Set("Content-Type", "application/json")
 		expectedBody := map[string]interface{}{
-			"username":     "test",
-			"password":     "test",
-			"databaseName": "test",
+			"username":        "test",
+			"password":        "test",
+			"databaseName":    "test",
+			"deleteAfterDate": "2100-01-01T00:00:00Z",
 			"roles": []interface{}{map[string]interface{}{
 				"databaseName": "test",
 				"roleName":     "read",
 			}},
 		}
 		assertReqJSON(t, expectedBody, r)
-		fmt.Fprintf(w, `{"databaseName":"test","username":"test","roles":[{"databaseName":"test","roleName":"read"}]}`)
+		fmt.Fprintf(w, `{"databaseName":"test","deleteAfterDate":"2100-01-01T00:00:00Z","username":"test","roles":[{"databaseName":"test","roleName":"read"}]}`)
 	})
 
 	client := NewClient(httpClient)
 	roles := []Role{Role{DatabaseName: "test", RoleName: "read"}}
-	params := &DatabaseUser{DatabaseName: "test", Username: "test", Password: "test", Roles: roles}
+	params := &DatabaseUser{DatabaseName: "test", DeleteAfterDate: "2100-01-01T00:00:00Z", Username: "test", Password: "test", Roles: roles}
 	databaseUser, _, err := client.DatabaseUsers.Create("123", params)
-	expected := &DatabaseUser{DatabaseName: "test", Username: "test", Roles: roles}
+	expected := &DatabaseUser{DatabaseName: "test", DeleteAfterDate: "2100-01-01T00:00:00Z", Username: "test", Roles: roles}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, databaseUser)
 }
@@ -79,21 +80,22 @@ func TestDatabaseUserService_Update(t *testing.T) {
 		assertMethod(t, "PATCH", r)
 		w.Header().Set("Content-Type", "application/json")
 		expectedBody := map[string]interface{}{
-			"password": "secure",
+			"password":        "secure",
+			"deleteAfterDate": "2100-01-02T00:00:00Z",
 			"roles": []interface{}{map[string]interface{}{
 				"databaseName": "test",
 				"roleName":     "readWrite",
 			}},
 		}
 		assertReqJSON(t, expectedBody, r)
-		fmt.Fprintf(w, `{"databaseName":"test","username":"test","roles":[{"databaseName":"test","roleName":"readWrite"}]}`)
+		fmt.Fprintf(w, `{"databaseName":"test","deleteAfterDate":"2100-01-02T00:00:00Z","username":"test","roles":[{"databaseName":"test","roleName":"readWrite"}]}`)
 	})
 
 	client := NewClient(httpClient)
 	roles := []Role{Role{DatabaseName: "test", RoleName: "readWrite"}}
-	params := &DatabaseUser{Password: "secure", Roles: roles}
+	params := &DatabaseUser{Password: "secure", DeleteAfterDate: "2100-01-02T00:00:00Z", Roles: roles}
 	databaseUser, _, err := client.DatabaseUsers.Update("123", "test", params)
-	expected := &DatabaseUser{DatabaseName: "test", Username: "test", Roles: roles}
+	expected := &DatabaseUser{DatabaseName: "test", DeleteAfterDate: "2100-01-02T00:00:00Z", Username: "test", Roles: roles}
 	assert.Nil(t, err)
 	assert.Equal(t, expected, databaseUser)
 }


### PR DESCRIPTION
Not sure if it was added recently,  but yeah, it's there and working fine: https://docs.atlas.mongodb.com/reference/api/database-users-create-a-user/