### PR TITLE
support custom API base URL

### DIFF
--- a/mongodbatlas/mongodb.go
+++ b/mongodbatlas/mongodb.go
@@ -6,7 +6,7 @@ import (
 	"github.com/dghubble/sling"
 )
 
-const apiURL = "https://cloud.mongodb.com/api/atlas/v1.0/"
+const atlasURL = "https://cloud.mongodb.com/api/atlas/v1.0/"
 
 // Client is a MongoDB Atlas client for making MongoDB API requests.
 type Client struct {
@@ -25,8 +25,13 @@ type Client struct {
 	PrivateIPMode       *PrivateIPModeService
 }
 
-// NewClient returns a new Client.
+// NewClient returns a new Client using MongoDB Atlas API Base URL
 func NewClient(httpClient *http.Client) *Client {
+	return NewCustomURLClient(httpClient, atlasURL)
+}
+
+// NewCustomURLClient returns a new Client using provided API Base URL
+func NewCustomURLClient(httpClient *http.Client, apiURL string) *Client {
 	base := sling.New().Client(httpClient).Base(apiURL)
 
 	return &Client{

--- a/mongodbatlas/root_test.go
+++ b/mongodbatlas/root_test.go
@@ -26,3 +26,22 @@ func TestRootService_Get(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, root)
 }
+
+func TestCloudManagerRootService_Get(t *testing.T) {
+	httpClient, mux, server := testServer()
+	defer server.Close()
+
+	mux.HandleFunc("/api/public/v1.0/", func(w http.ResponseWriter, r *http.Request) {
+		assertMethod(t, "GET", r)
+		fmt.Fprintf(w, `{"appName":"MongoDB Cloud Manager","build":"2cf9112fd6b8f59c03a9d1d4cbf32004424e728e","links":[{"href":"https://cloud.mongodb.com/api/public/v1.0","rel":"self"},{"href":"https://cloud.mongodb.com/api/public/v1.0/orgs/000000000000000000000000/apiKeys/000000000000000000000000","rel":"http://mms.mongodb.com/apiKeys"},{"href":"https://cloud.mongodb.com/api/public/v1.0/groups","rel":"http://mms.mongodb.com/groups"},{"href":"https://cloud.mongodb.com/api/public/v1.0/admin/backup","rel":"http://mms.mongodb.com/backupAdmin"}],"throttling":false}`)
+	})
+
+	client := NewCustomURLClient(httpClient, "https://cloud.mongodb.com/api/public/v1.0/")
+	root, _, err := client.Root.Get()
+	expected := &Root{
+		AppName: "MongoDB Cloud Manager",
+		Build:   "2cf9112fd6b8f59c03a9d1d4cbf32004424e728e",
+	}
+	assert.Nil(t, err)
+	assert.Equal(t, expected, root)
+}


### PR DESCRIPTION
It seems that MongoDB Atlas shares API with Cloud Manager and Ops Manager. The new function `NewCustomURLClient` provides interface for users to use this library with custom rest API base URL.

e.g. 
+ `https://cloud.mongodb.com/api/public/v1.0` for [Cloud Manager](https://docs.cloudmanager.mongodb.com/reference/api/root/)
+ `https://{OPSMANAGER-HOST}:{PORT}/api/public/v1.0` for [Ops Manager](https://docs.opsmanager.mongodb.com/current/reference/api/root/)